### PR TITLE
Handle JSON fetch failures gracefully

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,9 +1,18 @@
-export async function fetchMediaList() {
-  const res = await fetch('/api/media');
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `Request failed with ${res.status}: ${res.statusText}\n${text}`
+    );
+  }
   return res.json();
 }
 
-export async function fetchMediaItem(id) {
-  const res = await fetch(`/api/media/${id}`);
-  return res.json();
+export function fetchMediaList() {
+  return fetchJson('/api/media');
+}
+
+export function fetchMediaItem(id) {
+  return fetchJson(`/api/media/${id}`);
 }


### PR DESCRIPTION
## Summary
- improve error handling logic in API helpers

## Testing
- `npm run build`
- `npm start` *(fails: npm start not running?)*
- `curl -s http://localhost:3000/api/media | head`

------
https://chatgpt.com/codex/tasks/task_e_68588e96c1dc83209259a953a3b8c624